### PR TITLE
Fix java-snappy usage with glibc compatibility lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.4
 RUN apk update && \
     apk upgrade && \
     apk add --update --no-cache \
+            libc6-compat \
             openjdk8-jre \
             bash \
             drill \


### PR DESCRIPTION
Sending messages compressed with the Snappy codec ellicits the following error about a missing glibc dynamic linker library.

```
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.2-f400a49b-361b-4bcc-b80a-6e387edf0f72-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-1.1.2-f400a49b-361b-4bcc-b80a-6e387edf0f72-libsnappyjava.so)
```

[libc6-compat](https://pkgs.alpinelinux.org/package/v3.4/main/x86_64/libc6-compat) appears to resolve the issue by adding a symlink to a compatible musl library.
